### PR TITLE
Bump compile and target SDK level from 29 to 30

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -2,8 +2,8 @@ import org.gradle.api.JavaVersion
 
 object Config {
     const val minSdk = 23
-    const val compileSdk = 29
-    const val targetSdk = 29
+    const val compileSdk = 30
+    const val targetSdk = 30
     val javaVersion = JavaVersion.VERSION_1_8
 }
 


### PR DESCRIPTION
- To compile with Play Store policies and upcoming deadlines.

Smoke tested the app and ran all existing tests to ensure functionality is the same as before.

Signed-off-by: Antal János Monori <anthonymonori@gmail.com>