### PR TITLE
Drop the Jetifier

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -41,7 +41,7 @@ object Versions {
     const val arch_core = "2.1.0"
 
     // Bump Technologies
-    const val glide = "4.9.0"
+    const val glide = "4.12.0"
 
     // Square
     const val okhttp = "4.7.2"

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,6 @@
 
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-android.enableJetifier=true
 android.useAndroidX=true
 org.gradle.jvmargs=-Xmx1536m
 


### PR DESCRIPTION
### Context
Followed Adam Benett's super insightful blog post about it: https://adambennett.dev/2020/08/disabling-jetifier/
It was enabled back in 2017 when the first iteration of the codebase was written, and thankfully all dependencies dropped Android Support libraries in favor of AndroidX.

Measured the before/after mean build time: 

| Scenario | Mean | Min | P25 | Median | P75 | Max | Std.dev |
| -------- | ------ | ---- | ---- | -------- | --- | ----- | ------- |
| Before | 1,352.05 ms | 1,315.10 ms | 1,321.26 ms | 1,347.33 ms | 1,363.36 ms | 1,440.02 ms | 35.96 ms |
| After | 1,344.05 ms | 1,315.13 ms | 1,316.26 ms | 1,339.83 ms | 1,347.80 ms | 1,424.54 ms | 33.07 ms |
| Diff | -0.5952159517875079% |

### Changelog

- Upgraded last dependency that was on the old android.support libraries: Glide
- Measured a 0.6% relative increase in mean build time

Signed-off-by: Antal János Monori <anthonymonori@gmail.com>