### PR TITLE
Bump Gradle version from 6.8.1 to 6.8.2

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Feb 03 00:03:35 GMT 2021
+#Wed Mar 03 16:56:09 GMT 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Minimum supported Gradle version is 6.8.2. Current version is 6.8.1.

Signed-off-by: Antal János Monori <anthonymonori@gmail.com>