### PR TITLE
Remove jCenter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.0.0-alpha08'
@@ -16,7 +16,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         maven { url 'https://jitpack.io' }
     }
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,5 +1,5 @@
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 plugins {


### PR DESCRIPTION
- Replaced it with mavenCentral() since all of the dependencies are available there.

More info:
- https://developer.android.com/studio/build/jcenter-migration
- https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/

Signed-off-by: Antal János Monori <anthonymonori@gmail.com>