### PR TITLE
Add support for Compose in the project

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -53,7 +53,10 @@ android {
         xmlReport true
     }
 
-    buildFeatures.viewBinding true
+    buildFeatures {
+        viewBinding true
+        compose true
+    }
 
     buildTypes {
         release {
@@ -69,6 +72,10 @@ android {
 
     packagingOptions {
         exclude 'META-INF/**'
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion libs.versions.composeVersion.get()
     }
 }
 

--- a/features/splash/build.gradle
+++ b/features/splash/build.gradle
@@ -5,7 +5,10 @@ plugins {
 }
 
 android {
-    buildFeatures.viewBinding true
+    buildFeatures {
+        viewBinding true
+        compose true
+    }
 }
 
 dependencies {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,6 +35,7 @@ burstVersion = "1.2.0"
 leakCanaryVersion = "2.6"
 okhttpVersion = "4.7.2"
 retrofitVersion = "2.7.0"
+composeVersion = "1.0.0-beta07"
 
 [libraries]
 agp = { module = "com.android.tools.build :gradle", version.ref = "agpVersion" }
@@ -87,8 +88,12 @@ okhttp-mockwebserver = { module = "com.squareup.okhttp3 :mockwebserver", version
 leakcanary = { module = "com.squareup.leakcanary :leakcanary-android", version.ref = "leakCanaryVersion" }
 retrofit-core = { module = "com.squareup.retrofit2 :retrofit", version.ref = "retrofitVersion" }
 retrofit-ext-gson = { module = "com.squareup.retrofit2 :converter-gson", version.ref = "retrofitVersion" }
+compose-ui-core = { module = "androidx.compose.ui :ui", version.ref = "composeVersion" }
+compose-ui-tooling = { module = "androidx.compose.ui :ui-tooling", version.ref = "composeVersion" }
+compose-foundation = { module = "androidx.compose.foundation :foundation", version.ref = "composeVersion" }
 
 [bundles]
 androidx-navigation-component = ['androidx-navigation-component-fragment-ktx', 'androidx-navigation-component-ui-ktx']
 androidx-lifecycle = ['androidx-lifecycle-viewmodel-ktx', 'androidx-lifecycle-ext']
+compose = ['compose-ui-core', 'compose-ui-tooling', 'compose-foundation']
 glide = ['glide-core', 'glide-ext-okhttp3']

--- a/libraries/design/build.gradle
+++ b/libraries/design/build.gradle
@@ -6,6 +6,7 @@ plugins {
 dependencies {
     implementation libs.androidx.appcompat
     implementation libs.material.design
+    api libs.bundles.compose
 
     api libs.lottie
 }


### PR DESCRIPTION
- Define compose-ui, compose-ui-tooling and compose-foundation dependencies
- Required setup in build.gradle to enable compose

Signed-off-by: Antal János Monori <anthonymonori@gmail.com>