### PR TITLE
Fix leaks in bindings code

### DIFF
--- a/features/details/src/main/java/com/thirdwavelist/coficiando/details/presentation/DetailsFragment.kt
+++ b/features/details/src/main/java/com/thirdwavelist/coficiando/details/presentation/DetailsFragment.kt
@@ -25,7 +25,9 @@ import java.util.UUID
 @AndroidEntryPoint
 class DetailsFragment : Fragment() {
 
-    private lateinit var binding: FragmentDetailsBinding
+
+    private var _binding: FragmentDetailsBinding? = null
+    private val binding get() = _binding!!
     private val viewModel: DetailsFragmentViewModel by viewModels()
     private val args: DetailsFragmentArgs by navArgs()
 
@@ -35,7 +37,7 @@ class DetailsFragment : Fragment() {
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        binding = FragmentDetailsBinding.inflate(inflater, container, false)
+        _binding = FragmentDetailsBinding.inflate(inflater, container, false)
         return binding.root
     }
 
@@ -52,6 +54,11 @@ class DetailsFragment : Fragment() {
         }
 
         viewModel.loadCafe(UUID.fromString(args.id))
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     private fun handle(liveEvent: LiveEvent<DetailsEvents>) {

--- a/features/home/src/main/java/com/thirdwavelist/coficiando/home/presentation/CafeAdapter.kt
+++ b/features/home/src/main/java/com/thirdwavelist/coficiando/home/presentation/CafeAdapter.kt
@@ -47,6 +47,11 @@ class CafeAdapter : ListAdapter<CafeItem, CafeAdapter.CafeItemViewHolder>(diffUt
         }
     }
 
+    override fun onViewRecycled(holder: CafeItemViewHolder) {
+        super.onViewRecycled(holder)
+        holder.unBind()
+    }
+
     fun setOnItemClickListener(function: (CafeItem, List<Pair<View, String>>) -> Unit) {
         itemClickListener = function
     }
@@ -60,7 +65,11 @@ class CafeAdapter : ListAdapter<CafeItem, CafeAdapter.CafeItemViewHolder>(diffUt
                                  val hasSyphon: Boolean,
                                  val hasImmersive: Boolean)
 
-    class CafeItemViewHolder(private val binding: ItemCafeBinding) : RecyclerView.ViewHolder(binding.root) {
+    class CafeItemViewHolder(binding: ItemCafeBinding) : RecyclerView.ViewHolder(binding.root) {
+
+        private var _binding: ItemCafeBinding? = binding
+        private val binding get() = _binding!!
+
         fun bind(viewModel: Any) {
             when (viewModel) {
                 is CafeItemViewModel -> {
@@ -89,6 +98,10 @@ class CafeAdapter : ListAdapter<CafeItem, CafeAdapter.CafeItemViewHolder>(diffUt
                 }
             }
 
+        }
+
+        fun unBind() {
+            _binding = null
         }
     }
 }

--- a/features/home/src/main/java/com/thirdwavelist/coficiando/home/presentation/HomeFragment.kt
+++ b/features/home/src/main/java/com/thirdwavelist/coficiando/home/presentation/HomeFragment.kt
@@ -26,11 +26,13 @@ import dagger.hilt.android.AndroidEntryPoint
 class HomeFragment : Fragment() {
 
     private val viewModel: HomeFragmentViewModel by viewModels()
-    private lateinit var binding: FragmentHomeBinding
-    private lateinit var cafeAdapter: CafeAdapter
+    private var _binding: FragmentHomeBinding? = null
+    private val binding get() = _binding!!
+    private var _cafeAdapter: CafeAdapter? = null
+    private val cafeAdapter get() = _cafeAdapter!!
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        binding = FragmentHomeBinding.inflate(inflater, container, false)
+        _binding = FragmentHomeBinding.inflate(inflater, container, false)
         return binding.root
     }
 
@@ -40,7 +42,7 @@ class HomeFragment : Fragment() {
             v.updatePadding(top = insets.systemWindowInsetTop)
             insets
         }
-        cafeAdapter = CafeAdapter().apply {
+        _cafeAdapter = CafeAdapter().apply {
             setOnItemClickListener { cafeItem, sharedElementTransitions ->
                 viewModel.onCafeTapped(cafeItem, sharedElementTransitions)
             }
@@ -59,6 +61,12 @@ class HomeFragment : Fragment() {
         }
 
         viewModel.loadCafes()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+        _cafeAdapter = null
     }
 
     private fun handle(liveEvent: LiveEvent<HomeEvents>) {


### PR DESCRIPTION
## Changes

- ViewBindings were leaking when the Fragment was tried to be killed (navigating away, etc.)
- Same in adapter

Thanks to LeakCanary for catching them!

Signed-off-by: Antal János Monori <anthonymonori@gmail.com>

## Checklist
- [ ] Appropriate test coverage was added