### PR TITLE
chore: Update API 31 and latest AGP

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,8 @@
 
 ## How to run
 
-This project was written **using Android Studio Arctic Fox Patch 1**, and given the usage of Dagger Hilt, modularization and kapt,
-it is required to run it on AGP 7.1.0+ and make sure you have Java 11 installed (See caveats for more info).
-
-If the compiler is complaining about JDK 11 (in case you are not using the embedded one), make sure you install that first and check
-the Project Structure -> SDK Location -> JDK location settings.
-
-So to sum up, in order to compile and run the project you will need:
-- AS Arctic Fox Patch 1
+In order to compile and run the project you will need:
+- Android Studio supporting the Gradle plugin defined [here](https://github.com/thirdwavelist/android/blob/main/gradle/libs.versions.toml#L10)
 - Java 11 SDK installed
 
 ## Features:
@@ -32,13 +26,7 @@ So to sum up, in order to compile and run the project you will need:
 
 ## Caveats
 
-1. Running this project on older Android Studio that does not support running AGP 7.0.0 or higher,
-because of an experimental flag required to make the build of multi module kapt annotation more stable 
-for the Dagger Hilt library used across this project. While this is something that would not be acceptable 
-at a large scale in an organization, for a project like this, I have accepted this drawback in hindsight,
-since Dagger Hilt gave a lot more help in writing succinct, boilerplate free code.
-
-2. The original codebase that was written >3 years ago was built on pure MVVM approach (with DataBinding and a bi-directional data flow).
+1. The original codebase that was written >3 years ago was built on pure MVVM approach (with DataBinding and a bi-directional data flow).
 This was problematic, since it didn't reflect my current thinking and its also going against some bigger trends in the industry: 
 Compose (Data Binding is problematic), MVI (bi-directional data flow is problematic), so I removed the use of Data Binding, replaced it with ViewBinding,
 finite View State (machine), and while I didn't really capture true unidirectional data flow (UDF), it also does not go against some of the practices
@@ -60,7 +48,7 @@ would have required me to touch the API (which I developed as well 3 years ago),
 ```Text
 BSD 3-Clause License
 
-Copyright (c) 2017 - 2021, Antal János Monori & Kristoffer Tjalve
+Copyright (c) 2017 - 2022, Antal János Monori & Kristoffer Tjalve
 All rights reserved.
 ```
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -82,7 +82,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion libs.versions.composeVersion.get()
+        kotlinCompilerExtensionVersion libs.versions.androidComposeVersion.get()
     }
 }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,6 +25,7 @@
         <activity
             android:name=".presentation.MainActivity"
             android:theme="@style/AppTheme"
+            android:exported="true"
             >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/build.gradle
+++ b/build.gradle
@@ -22,11 +22,11 @@ subprojects {
     afterEvaluate { project ->
         if (project.hasProperty('android')) {
             android {
-                compileSdkVersion 30
+                compileSdkVersion 31
 
                 defaultConfig {
                     minSdkVersion 23
-                    targetSdkVersion 30
+                    targetSdkVersion 31
                     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
                 }
 

--- a/features/details/src/main/java/com/thirdwavelist/coficiando/details/presentation/DetailsFragment.kt
+++ b/features/details/src/main/java/com/thirdwavelist/coficiando/details/presentation/DetailsFragment.kt
@@ -33,7 +33,7 @@ class DetailsFragment : Fragment() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        sharedElementEnterTransition = TransitionInflater.from(context).inflateTransition(android.R.transition.move)
+        sharedElementEnterTransition = TransitionInflater.from(requireContext()).inflateTransition(android.R.transition.move)
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,111 +1,111 @@
 [versions]
-agpVersion = "7.3.0-alpha09"
-kotlinVersion = "1.5.21"
-coroutinesVersion = "1.5.1"
-lottieVersion = "3.6.0"
-googleServicesVersion = "4.3.5"
-navigationComponentVersion = "2.3.3"
-daggerVersion = "2.38.1"
-gsonVersion = "2.8.6"
-firebaseBomVersion = "26.4.0"
-crashlyticsVersion = "2.4.1"
-appCompatVersion = "1.2.0"
-constraintLayoutVersion = "2.0.4"
-materialDesignVersion = "1.2.1"
-recyclerViewVersion = "1.1.0"
-cardViewVersion = "1.0.0"
-coreKtxVersion = "1.3.2"
-fragmentKtxVersion = "1.2.5"
-roomVersion = "2.2.6"
-lifecycleVersion = "2.2.0"
-preferenceVersion = "1.1.1"
-testRunnerVersion = "1.3.0"
-testCoreVersion = "1.3.0"
-espressoVersion = "3.3.0"
-extJunitVersion = "1.1.2"
-archCoreVersion = "2.1.0"
-glideVersion = "4.12.0"
-timberVersion = "4.7.1"
-mockitoKotlinVersion = "2.2.0"
-mockitoInlineVersion = "3.1.0"
-assertJVersion = "3.19.0"
-jUnitVersion = "4.13.1"
-networkAdapterVersion = "4.1.0"
-burstVersion = "1.2.0"
-leakCanaryVersion = "2.6"
-okhttpVersion = "4.7.2"
-retrofitVersion = "2.7.0"
-composeVersion = "1.0.1"
-versionCatalogUpdate = "0.3.1"
+androidAppCompatVersion = "1.5.0-alpha01"
+androidArchCoreVersion = "2.1.0"
+androidCardViewVersion = "1.0.0"
+androidComposeVersion = "1.2.0-beta01"
+androidConstraintLayoutVersion = "2.1.3"
+androidCoreVersion = "1.8.0-rc01"
+androidEspressoVersion = "3.5.0-alpha05"
+androidFragmentVersion = "1.5.0-beta01"
+androidGradlePluginVersion = "7.4.0-alpha02"
+androidJunitVersion = "1.1.4-alpha05"
+androidLifecycleVersion = "2.2.0"
+androidNavigationComponentVersion = "2.5.0-beta01"
+androidPreferenceVersion = "1.2.0"
+androidRecyclerViewVersion = "1.3.0-alpha02"
+androidRoomVersion = "2.5.0-alpha01"
+androidTestCoreVersion = "1.4.1-alpha05"
+androidTestRunnerVersion = "1.5.0-alpha02"
+appDistributionVersion = "3.0.1"
+assertJVersion = "3.22.0"
 benManesVersion = "0.42.0"
-appDistributionVersion = "2.2.0"
-gradlePlayPublisherVersion = "3.6.0"
+burstVersion = "1.2.0"
+daggerVersion = "2.41"
+firebaseBomVersion = "29.3.1"
+firebaseCrashlyticsVersion = "2.8.1"
+glideVersion = "4.13.1"
+googleServicesVersion = "4.3.10"
+gradlePlayPublisherVersion = "3.7.0"
+gsonVersion = "2.9.0"
+jUnitVersion = "4.13.2"
+kotlinCoroutinesVersion = "1.6.1"
+kotlinVersion = "1.6.21"
+leakCanaryVersion = "2.9.1"
+lottieVersion = "5.0.3"
+materialDesignVersion = "1.7.0-alpha01"
+mockitoInlineVersion = "4.5.1"
+mockitoKotlinVersion = "2.2.0"
+networkAdapterVersion = "5.0.0"
+okhttpVersion = "5.0.0-alpha.6"
+retrofitVersion = "2.9.0"
+timberVersion = "5.0.1"
+versionCatalogUpdate = "0.3.1"
 
 [libraries]
-agp = { module = "com.android.tools.build:gradle", version.ref = "agpVersion" }
-kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlinVersion" }
-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutinesVersion" }
-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutinesVersion" }
-lottie = { module = "com.airbnb.android:lottie", version.ref = "lottieVersion" }
+agp = { module = "com.android.tools.build:gradle", version.ref = "androidGradlePluginVersion" }
+androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidAppCompatVersion" }
+androidx-arch-core-testing = { module = "androidx.arch.core:core-testing", version.ref = "androidArchCoreVersion" }
+androidx-cardview = { module = "androidx.cardview:cardview", version.ref = "androidCardViewVersion" }
+androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "androidConstraintLayoutVersion" }
+androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidCoreVersion" }
+androidx-fragment-ktx = { module = "androidx.fragment:fragment-ktx", version.ref = "androidFragmentVersion" }
+androidx-lifecycle-ext = { module = "androidx.lifecycle:lifecycle-extensions", version.ref = "androidLifecycleVersion" }
+androidx-lifecycle-viewmodel-ktx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "androidLifecycleVersion" }
+androidx-navigation-component-fragment-ktx = { module = "androidx.navigation:navigation-fragment-ktx", version.ref = "androidNavigationComponentVersion" }
+androidx-navigation-component-safe-args-gradle = { module = "androidx.navigation:navigation-safe-args-gradle-plugin", version.ref = "androidNavigationComponentVersion" }
+androidx-navigation-component-ui-ktx = { module = "androidx.navigation:navigation-ui-ktx", version.ref = "androidNavigationComponentVersion" }
+androidx-preference-ktx = { module = "androidx.preference:preference-ktx", version.ref = "androidPreferenceVersion" }
+androidx-recyclerview = { module = "androidx.recyclerview:recyclerview", version.ref = "androidRecyclerViewVersion" }
+androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "androidRoomVersion" }
+androidx-room-ktx = { module = "androidx.room:room-ktx", version.ref = "androidRoomVersion" }
+androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "androidRoomVersion" }
+androidx-test-core = { module = "androidx.test:core", version.ref = "androidTestCoreVersion" }
+androidx-test-espresso = { module = "androidx.test.espresso:espresso-core", version.ref = "androidEspressoVersion" }
+androidx-test-junit = { module = "androidx.test.ext:junit", version.ref = "androidJunitVersion" }
+androidx-test-runner = { module = "androidx.test:runner", version.ref = "androidTestRunnerVersion" }
+assertj = { module = "org.assertj:assertj-core", version.ref = "assertJVersion" }
+burst = { module = "com.squareup.burst:burst-junit4", version.ref = "burstVersion" }
+compose-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "androidComposeVersion" }
+compose-ui-core = { module = "androidx.compose.ui:ui", version.ref = "androidComposeVersion" }
+compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "androidComposeVersion" }
+coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinCoroutinesVersion" }
+coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinCoroutinesVersion" }
+firebase-analytics = { module = "com.google.firebase:firebase-analytics" }
+firebase-appdistribution-gradle = { module = "com.google.firebase:firebase-appdistribution-gradle", version.ref = "appDistributionVersion" }
+firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBomVersion" }
+firebase-config = { module = "com.google.firebase:firebase-config-ktx" }
+firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics" }
+firebase-crashlytics-gradle = { module = "com.google.firebase:firebase-crashlytics-gradle", version.ref = "firebaseCrashlyticsVersion" }
+glide-compiler = { module = "com.github.bumptech.glide:okhttp3-integration", version.ref = "glideVersion" }
+glide-core = { module = "com.github.bumptech.glide:glide", version.ref = "glideVersion" }
+glide-ext-okhttp3 = { module = "com.github.bumptech.glide:compiler", version.ref = "glideVersion" }
+gson = { module = "com.google.code.gson:gson", version.ref = "gsonVersion" }
 hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "daggerVersion" }
 hilt-compiler = { module = "com.google.dagger:hilt-android-compiler", version.ref = "daggerVersion" }
 hilt-gradle = { module = "com.google.dagger:hilt-android-gradle-plugin", version.ref = "daggerVersion" }
-gson = { module = "com.google.code.gson:gson", version.ref = "gsonVersion" }
-firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBomVersion" }
-firebase-analytics = { module = "com.google.firebase:firebase-analytics" }
-firebase-appdistribution-gradle = { module = "com.google.firebase:firebase-appdistribution-gradle", version.ref = "appDistributionVersion" }
-firebase-config = { module = "com.google.firebase:firebase-config-ktx" }
-firebase-crashlytics-gradle = { module = "com.google.firebase:firebase-crashlytics-gradle", version.ref = "crashlyticsVersion" }
-firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics" }
-androidx-navigation-component-fragment-ktx = { module = "androidx.navigation:navigation-fragment-ktx", version.ref = "navigationComponentVersion" }
-androidx-navigation-component-ui-ktx = { module = "androidx.navigation:navigation-ui-ktx", version.ref = "navigationComponentVersion" }
-androidx-navigation-component-safe-args-gradle = { module = "androidx.navigation:navigation-safe-args-gradle-plugin", version.ref = "navigationComponentVersion" }
-androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appCompatVersion" }
-androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "constraintLayoutVersion" }
-material-design = { module = "com.google.android.material:material", version.ref = "materialDesignVersion" }
-androidx-recyclerview = { module = "androidx.recyclerview:recyclerview", version.ref = "recyclerViewVersion" }
-androidx-cardview = { module = "androidx.cardview:cardview", version.ref = "cardViewVersion" }
-androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "coreKtxVersion" }
-androidx-fragment-ktx = { module = "androidx.fragment:fragment-ktx", version.ref = "fragmentKtxVersion" }
-androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "roomVersion" }
-androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "roomVersion" }
-androidx-room-ktx = { module = "androidx.room:room-ktx", version.ref = "roomVersion" }
-androidx-lifecycle-viewmodel-ktx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "lifecycleVersion" }
-androidx-lifecycle-ext = { module = "androidx.lifecycle:lifecycle-extensions", version.ref = "lifecycleVersion" }
-androidx-preference-ktx = { module = "androidx.preference:preference-ktx", version.ref = "preferenceVersion" }
-androidx-test-core = { module = "androidx.test:core", version.ref = "testCoreVersion" }
-androidx-test-runner = { module = "androidx.test:runner", version.ref = "testRunnerVersion" }
-androidx-test-espresso = { module = "androidx.test.espresso:espresso-core", version.ref = "espressoVersion" }
-androidx-test-junit = { module = "androidx.test.ext:junit", version.ref = "extJunitVersion" }
-androidx-arch-core-testing = { module = "androidx.arch.core:core-testing", version.ref = "archCoreVersion" }
-glide-core = { module = "com.github.bumptech.glide:glide", version.ref = "glideVersion" }
-glide-compiler = { module = "com.github.bumptech.glide:okhttp3-integration", version.ref = "glideVersion" }
-glide-ext-okhttp3 = { module = "com.github.bumptech.glide:compiler", version.ref = "glideVersion" }
-timber = { module = "com.jakewharton.timber:timber", version.ref = "timberVersion" }
-mockito-kotlin = { module = "com.nhaarman.mockitokotlin2:mockito-kotlin", version.ref = "mockitoKotlinVersion" }
-mockito-inline = { module = "org.mockito:mockito-inline", version.ref = "mockitoInlineVersion" }
-assertj = { module = "org.assertj:assertj-core", version.ref = "assertJVersion" }
 junit = { module = "junit:junit", version.ref = "jUnitVersion" }
+kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlinVersion" }
+leakcanary = { module = "com.squareup.leakcanary:leakcanary-android", version.ref = "leakCanaryVersion" }
+lottie = { module = "com.airbnb.android:lottie", version.ref = "lottieVersion" }
+material-design = { module = "com.google.android.material:material", version.ref = "materialDesignVersion" }
+mockito-inline = { module = "org.mockito:mockito-inline", version.ref = "mockitoInlineVersion" }
+mockito-kotlin = { module = "com.nhaarman.mockitokotlin2:mockito-kotlin", version.ref = "mockitoKotlinVersion" }
 network-adapter = { module = "com.github.haroldadmin:NetworkResponseAdapter", version.ref = "networkAdapterVersion" }
-burst = { module = "com.squareup.burst:burst-junit4", version.ref = "burstVersion" }
 okhttp-core = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttpVersion" }
 okhttp-logging-interceptor = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttpVersion" }
 okhttp-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okhttpVersion" }
-leakcanary = { module = "com.squareup.leakcanary:leakcanary-android", version.ref = "leakCanaryVersion" }
 retrofit-core = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofitVersion" }
 retrofit-ext-gson = { module = "com.squareup.retrofit2:converter-gson", version.ref = "retrofitVersion" }
-compose-ui-core = { module = "androidx.compose.ui:ui", version.ref = "composeVersion" }
-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "composeVersion" }
-compose-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "composeVersion" }
+timber = { module = "com.jakewharton.timber:timber", version.ref = "timberVersion" }
 
 [bundles]
-androidx-navigation-component = ['androidx-navigation-component-fragment-ktx', 'androidx-navigation-component-ui-ktx']
-androidx-lifecycle = ['androidx-lifecycle-viewmodel-ktx', 'androidx-lifecycle-ext']
-compose = ['compose-ui-core', 'compose-ui-tooling', 'compose-foundation']
-glide = ['glide-core', 'glide-ext-okhttp3']
+androidx-lifecycle = ["androidx-lifecycle-ext", "androidx-lifecycle-viewmodel-ktx"]
+androidx-navigation-component = ["androidx-navigation-component-fragment-ktx", "androidx-navigation-component-ui-ktx"]
+android-compose = ["compose-foundation", "compose-ui-core", "compose-ui-tooling"]
+glide = ["glide-core", "glide-ext-okhttp3"]
 
 [plugins]
 googleServices-gradlePlugin = { id = "com.google.gms.google-services", version.ref = "googleServicesVersion" }
-versions-gradlePlugin = { id = "com.github.ben-manes.versions", version.ref = "benManesVersion" }
-versionCatalogUpdate-gradlePlugin = { id = "nl.littlerobots.version-catalog-update", version.ref = "versionCatalogUpdate" }
 tripletPlay-gradlePlugin = { id = "com.github.triplet.play", version.ref = "gradlePlayPublisherVersion" }
+versionCatalogUpdate-gradlePlugin = { id = "nl.littlerobots.version-catalog-update", version.ref = "versionCatalogUpdate" }
+versions-gradlePlugin = { id = "com.github.ben-manes.versions", version.ref = "benManesVersion" }

--- a/libraries/core/src/test/java/com/thirdwavelist/coficiando/core/data/network/ThirdWaveListServiceTest.kt
+++ b/libraries/core/src/test/java/com/thirdwavelist/coficiando/core/data/network/ThirdWaveListServiceTest.kt
@@ -16,6 +16,7 @@ import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import java.net.HttpURLConnection
 import java.util.UUID
+import java.util.function.Consumer
 
 class ThirdWaveListServiceTest {
 
@@ -52,11 +53,11 @@ class ThirdWaveListServiceTest {
         val result = api.getCafes()
 
         // Then
-        assertThat((result as NetworkResponse.Success)).satisfies {
+        assertThat((result as NetworkResponse.Success)).satisfies(Consumer {
             assertThat(it.code).isEqualTo(200)
             assertThat(it.body.size).isEqualTo(2)
             assertThat(it.body).usingRecursiveComparison().isEqualTo(CafeItemResponseBuilder.multiple())
-        }
+        })
     }
 
     @Test
@@ -71,10 +72,10 @@ class ThirdWaveListServiceTest {
         val result = api.getCafes()
 
         // Then
-        assertThat((result as NetworkResponse.ServerError)).satisfies {
+        assertThat((result as NetworkResponse.ServerError)).satisfies(Consumer {
             assertThat(it.code).isEqualTo(403)
             assertThat(it.body).usingRecursiveComparison().isEqualTo(CafeItemResponseBuilder.forbidden())
-        }
+        })
     }
 
     @Test
@@ -90,10 +91,10 @@ class ThirdWaveListServiceTest {
         val result = api.getCafe(cafeId)
 
         // Then
-        assertThat((result as NetworkResponse.Success)).satisfies {
+        assertThat((result as NetworkResponse.Success)).satisfies(Consumer {
             assertThat(it.code).isEqualTo(200)
             assertThat(it.body).usingRecursiveComparison().isEqualTo(CafeItemResponseBuilder.single())
-        }
+        })
     }
 
     @Test
@@ -108,9 +109,9 @@ class ThirdWaveListServiceTest {
         val result = api.getCafe(UUID.randomUUID())
 
         // Then
-        assertThat((result as NetworkResponse.ServerError)).satisfies {
+        assertThat((result as NetworkResponse.ServerError)).satisfies(Consumer {
             assertThat(it.code).isEqualTo(403)
             assertThat(it.body).usingRecursiveComparison().isEqualTo(CafeItemResponseBuilder.forbidden())
-        }
+        })
     }
 }

--- a/libraries/design/build.gradle
+++ b/libraries/design/build.gradle
@@ -6,7 +6,7 @@ plugins {
 dependencies {
     implementation libs.androidx.appcompat
     implementation libs.material.design
-    api libs.bundles.compose
+    api libs.bundles.android.compose
 
     api libs.lottie
 }


### PR DESCRIPTION
## Changes

This project is now compatible with latest AGP 7.4.0 and canary version of the IDE. Updated some libraries, re-ordered the libs.versions.toml file, bumped to latest stable Android API (31) and minor code/documentation modifications.

Signed-off-by: Antal János Monori <anthonymonori@gmail.com>

## Checklist
- [n/a] Appropriate test coverage was added