### PR TITLE
Adopt `anthonymonori/android-ci-image` container image for GHA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,11 +9,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    container:
+      image: anthonymonori/android-ci-image:v2.0.0-rc01
     timeout-minutes: 30
-    strategy:
-      fail-fast: false
-      matrix:
-        java: [ '11' ]
     steps:
       - name: Checkout the code
         uses: actions/checkout@v3
@@ -29,12 +27,6 @@ jobs:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ matrix.java }}-${{ hashFiles('checksum.txt') }}
           restore-keys: ${{ runner.os }}-gradle-${{ matrix.java }}-
-
-      - name: Install JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'adopt'
-          java-version: ${{ matrix.java }}
 
       - name: Run Tests
         run: ./gradlew test --stacktrace

--- a/.github/workflows/publish_on_main.yml
+++ b/.github/workflows/publish_on_main.yml
@@ -9,28 +9,20 @@ on:
 jobs:
   publish_on_main:
     runs-on: ubuntu-latest
+    container:
+      image: anthonymonori/android-ci-image:v2.0.0-rc01
     timeout-minutes: 30
     env:
       ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
       ANDROID_KEYSTORE_ALIAS: ${{ secrets.ANDROID_KEYSTORE_ALIAS }}
       ANDROID_KEYSTORE_PRIVATE_KEY_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PRIVATE_KEY_PASSWORD }}
       FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
-    strategy:
-      fail-fast: false
-      matrix:
-        java: [ '11' ]
     steps:
       - name: Checkout the code
         uses: actions/checkout@v3
 
       - name: Gradle Wrapper Validation
         uses: gradle/wrapper-validation-action@v1
-
-      - name: Install JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'adopt'
-          java-version: ${{ matrix.java }}
 
       - name: Generate Keystore file
         env:

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -7,27 +7,19 @@ on:
 jobs:
   publish_release:
     runs-on: ubuntu-latest
+    container:
+      image: anthonymonori/android-ci-image:v2.0.0-rc01
     timeout-minutes: 30
     env:
       ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
       ANDROID_KEYSTORE_ALIAS: ${{ secrets.ANDROID_KEYSTORE_ALIAS }}
       ANDROID_KEYSTORE_PRIVATE_KEY_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PRIVATE_KEY_PASSWORD }}
-    strategy:
-      fail-fast: false
-      matrix:
-        java: [ '11' ]
     steps:
       - name: Checkout the code
         uses: actions/checkout@v3
 
       - name: Gradle Wrapper Validation
         uses: gradle/wrapper-validation-action@v1
-
-      - name: Install JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'adopt'
-          java-version: ${{ matrix.java }}
 
       - name: Generate Keystore and Play Service Account file
         env:


### PR DESCRIPTION
## Changes

This PR implements the use of [anthonymonori/android-ci-image](https://github.com/anthonymonori/android-ci-image) as the default container to be used for GitHub Actions.

Signed-off-by: Antal János Monori <anthonymonori@gmail.com>

## Checklist
- [n/a] Appropriate test coverage was added