### PR TITLE
Add appId for firebaseAppDistribution plugin

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -66,6 +66,7 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             firebaseAppDistribution {
                 artifactType="AAB"
+                appId="1:247998859063:android:87af47d61baef106"
             }
 
         }


### PR DESCRIPTION
## Changes

This property is required since we don't use `google-services.json` anymore since #82 and overlooked this bit of information: https://firebase.google.com/docs/app-distribution/android/distribute-gradle?apptype=aab#3_configure_your_distribution_properties

Signed-off-by: Antal János Monori <anthonymonori@gmail.com>

## Checklist
- [n/a] Appropriate test coverage was added